### PR TITLE
Add sort functionality

### DIFF
--- a/src/main/java/duke/CommandWords.java
+++ b/src/main/java/duke/CommandWords.java
@@ -4,5 +4,5 @@ package duke;
  * Commands that the user can use in the Duke Application.
  */
 public enum CommandWords {
-    BYE, LIST, UNMARK, MARK, TODO, EVENT, DEADLINE, DELETE, FIND
+    BYE, LIST, UNMARK, MARK, TODO, EVENT, DEADLINE, DELETE, FIND, SORT
 }

--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -2,6 +2,7 @@ package duke;
 
 import duke.exception.DukeException;
 import duke.exception.DukeRuntimeException;
+import duke.task.DatedTask;
 import duke.task.Deadline;
 import duke.task.Event;
 import duke.task.Task;
@@ -10,6 +11,7 @@ import duke.task.Todo;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
 
 /**
  * Represents the list of tasks that have been created in the Duke application.
@@ -96,6 +98,54 @@ public class TaskList {
             }
         }
         return foundTasks;
+    }
+
+    /**
+     * Returns TaskList containing all tasks in sorted order.
+     * @param taskType Type of tasks to be sorted - Deadline, event or both.
+     * @return TaskList containing matching tasks in sorted order.
+     */
+    public TaskList sort(String taskType) {
+        ArrayList<DatedTask> filteredTasks = filterByDatedTask(taskType);
+        filteredTasks.sort((x, y) -> x.compareTo(y));
+        TaskList sortedTasks = new TaskList();
+        for (Task sortedTask : filteredTasks) {
+            sortedTasks.addTask(sortedTask);
+        }
+        return sortedTasks;
+    }
+
+    private ArrayList<DatedTask> filterByDatedTask(String taskType) {
+        ArrayList<DatedTask> filteredList = new ArrayList<>();
+        switch (taskType) {
+        case "deadline":
+            for (Task task : tasks) {
+                if (task instanceof Deadline) {
+                    DatedTask datedTask = (DatedTask) task;
+                    filteredList.add(datedTask);
+                }
+            }
+            break;
+        case "event":
+            for (Task task : tasks) {
+                if (task instanceof Event) {
+                    DatedTask datedTask = (DatedTask) task;
+                    filteredList.add(datedTask);
+                }
+            }
+            break;
+        case "dated":
+            for (Task task : tasks) {
+                if (task instanceof DatedTask) {
+                    DatedTask datedTask = (DatedTask) task;
+                    filteredList.add(datedTask);
+                }
+            }
+            break;
+        default:
+            throw new DukeRuntimeException("TaskList::filter invalid task type entered.");
+        }
+        return filteredList;
     }
 
     /**

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -21,7 +21,7 @@ public class FindCommand extends Command{
 
     /**
      * Executes this command.
-     * @param tasks Task list to be listed.
+     * @param tasks Task list to find from.
      * @param storage Storage used in application.
      * @return The response of the execution.
      */

--- a/src/main/java/duke/command/SortCommand.java
+++ b/src/main/java/duke/command/SortCommand.java
@@ -1,0 +1,45 @@
+package duke.command;
+
+import duke.exception.DukeException;
+import duke.Response;
+import duke.Storage;
+import duke.TaskList;
+
+import duke.task.Task;
+
+/**
+ * Represents a command to sort dated tasks according to their dates.
+ */
+public class SortCommand extends Command {
+
+    /* Type of task to be shown - Event, Deadline or both */
+    private String taskType;
+
+    /**
+     * Initialises the SortCommand with the task type of tasks to be sorted.
+     * @param taskType Type of tasks to be displayed.
+     */
+    public SortCommand(String taskType) {
+        this.taskType = taskType;
+    }
+
+    /**
+     * Initialises the SortCommand with all deadline and events to be sorted.
+     */
+    public SortCommand() {
+        this.taskType = "dated";
+    }
+
+    /**
+     * Executes this command to sort all deadlines and events, or just deadlines or events.
+     * @param tasks Task list that contains tasks to be sorted.
+     * @param storage Storage used in application.
+     * @return The response of the execution.
+     */
+    @Override
+    public Response execute(TaskList tasks, Storage storage) {
+        TaskList sortedTasks = tasks.sort(taskType);
+        String message = sortedTasks.toString();
+        return new Response(message, false);
+    };
+}

--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -8,6 +8,7 @@ import duke.command.ExitCommand;
 import duke.command.FindCommand;
 import duke.command.ListCommand;
 import duke.command.MarkCommand;
+import duke.command.SortCommand;
 import duke.command.UnmarkCommand;
 import duke.exception.DukeException;
 import duke.task.Deadline;
@@ -65,6 +66,17 @@ public class Parser {
                 throw new DukeException("The keyword to search for cannot be empty.");
             }
             return new FindCommand(input.substring(5));
+        case SORT:
+            int commandLength = 4;
+            if (input.length() == commandLength) {
+                return new SortCommand();
+            }
+            if (input.equals("sort deadline")) {
+                return new SortCommand("deadline");
+            }
+            if (input.equals("sort event")) {
+                return new SortCommand("event");
+            }
         default:
             throw new DukeException("I'm sorry, but I don't know what that means :-(");
         }
@@ -89,6 +101,8 @@ public class Parser {
             return CommandWords.DELETE;
         } else if (input.length() > 3 && input.substring(0, 4).equals("find")) {
             return CommandWords.FIND;
+        } else if (input.length() > 3 && input.substring(0, 4).equals("sort")) {
+            return CommandWords.SORT;
         } else {
             throw new DukeException("I'm sorry, but I don't know what that means :-(");
         }

--- a/src/main/java/duke/task/DatedTask.java
+++ b/src/main/java/duke/task/DatedTask.java
@@ -1,0 +1,32 @@
+package duke.task;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a task that is associated with a date.
+ */
+abstract public class DatedTask extends Task {
+
+    /**
+     * Initialises a Task with its description.
+     *
+     * @param description Description of the Task.
+     */
+    public DatedTask(String description) {
+        super(description);
+    }
+
+    /**
+     * Checks if another DatedTask occurs later or earlier than self.
+     * @param task Task to compare to.
+     * @return returns 1 if self is later than task, -1 if task if it is earlier.
+     */
+    public abstract int compareTo(DatedTask task);
+
+    /**
+     * Gets the date the task occurs/is due.
+     * @return LocalDateTime of date.
+     */
+    public abstract LocalDateTime getDate();
+
+}

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 /**
  * Represents a task that has a deadline.
  */
-public class Deadline extends Task {
+public class Deadline extends DatedTask {
 
     private LocalDateTime by;
 
@@ -20,10 +20,16 @@ public class Deadline extends Task {
         this.by = by;
     }
 
-    /**
-     * Gets String representation of this deadline.
-     * @return String representation of this deadline.
-     */
+    @Override
+    public LocalDateTime getDate() {
+        return by;
+    }
+
+    @Override
+    public int compareTo(DatedTask task) {
+        return this.by.isAfter(task.getDate()) ? 1 : -1;
+    }
+
     @Override
     public String toString() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -2,11 +2,12 @@ package duke.task;
 
 import java.time.format.DateTimeFormatter;
 import java.time.LocalDateTime;
+import java.util.Date;
 
 /**
  * Represents a task that occurs at a specific time.
  */
-public class Event extends Task {
+public class Event extends DatedTask {
 
     private LocalDateTime at;
 
@@ -20,10 +21,16 @@ public class Event extends Task {
         this.at = at;
     }
 
-    /**
-     * Gets String representation of this event.
-     * @return String representation of this event.
-     */
+    @Override
+    public LocalDateTime getDate() {
+        return at;
+    }
+
+    @Override
+    public int compareTo(DatedTask task) {
+        return this.at.isAfter(task.getDate()) ? 1 : -1;
+    }
+
     @Override
     public String toString() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -13,10 +13,6 @@ public class Todo extends Task {
         super(description);
     }
 
-    /**
-     * Gets String representation of this todo.
-     * @return String representation of this todo.
-     */
     @Override
     public String toString() {
         return "[T]" + super.toString();


### PR DESCRIPTION
Order in which tasks are displayed is determined by time in which they are added.

This is not very friendly to users who want to know what they should prioritise first. Adding a sort functionality will help users know what is coming up easily.

Let's
* add a sort function for deadlines alone, events alone, and both deadlines and events.

Users might want to view deadlines by when they are due alone. so that they can start working on these tasks. They might also want to view sorted events alone to know what is coming up and that they have to attend. They might also want to view both deadlines and events together to plan their schedule accordingly.